### PR TITLE
Fix minutes and seconds rounding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+- Fix the display of minutes and seconds of `Progress.Units.seconds` and
+  `Progress_unix.counter`. (#6, @Ngoguey42)
+
 ### 0.1.1 (2020-10-13)
 
 - Rename `Progress.with_display` to `Progress.with_reporters`. (#3, @CraigFe)

--- a/src/progress/units.ml
+++ b/src/progress/units.ml
@@ -61,7 +61,8 @@ let bytes f = f ~width:(snd Bytes.pp_fixed) (fst Bytes.pp_fixed)
 let seconds f =
   let pp ppf span =
     let seconds = Mtime.Span.to_s span in
-    Format.fprintf ppf "%02.0f:%02.0f" (Float.div seconds 60.)
-      (Float.rem seconds 60.)
+    Format.fprintf ppf "%02.0f:%02.0f"
+      (Float.div seconds 60. |> Float.floor)
+      (Float.rem seconds 60. |> Float.floor)
   in
   f ~width:5 pp

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name main)
- (libraries progress alcotest astring fmt))
+ (libraries progress alcotest astring fmt mtime))

--- a/test/main.ml
+++ b/test/main.ml
@@ -49,6 +49,20 @@ module Units = struct
     expect "   1.0 PiB" (pib 1);
     expect "   1.0 EiB" (pib 1024);
     ()
+
+  let test_seconds () =
+    let pp ppf span =
+      Progress.Units.seconds (fun ~width:_ pp_time -> pp_time ppf span)
+    in
+    let expect = expect_pp_fixed (pp, 5) in
+    expect "00:00" (Mtime.Span.of_uint64_ns 0L);
+    expect "00:29" (Mtime.Span.of_uint64_ns 29_600_000_000L);
+    expect "00:30" (Mtime.Span.of_uint64_ns 30_000_000_000L);
+    expect "00:30" (Mtime.Span.of_uint64_ns 30_400_000_000L);
+    expect "00:59" (Mtime.Span.of_uint64_ns 59_600_000_000L);
+    expect "01:00" (Mtime.Span.of_uint64_ns 60_000_000_000L);
+    expect "01:00" (Mtime.Span.of_uint64_ns 60_400_000_000L);
+    ()
 end
 
 let test_pair () =
@@ -243,5 +257,6 @@ let () =
         [
           test_case "percentage" `Quick Units.test_percentage;
           test_case "bytes" `Quick Units.test_bytes;
+          test_case "seconds" `Quick Units.test_seconds;
         ] );
     ]


### PR DESCRIPTION
```
seconds: 0.0, div: 0.0, rem: 0.0, master:00:00, this-pr:00:00
seconds:29.6, div: 0.5, rem:29.6, master:00:30, this-pr:00:29
seconds:30.0, div: 0.5, rem:30.0, master:00:30, this-pr:00:30
seconds:30.4, div: 0.5, rem:30.4, master:01:30, this-pr:00:30
seconds:59.6, div: 1.0, rem:59.6, master:01:60, this-pr:00:59
seconds:60.0, div: 1.0, rem: 0.0, master:01:00, this-pr:01:00
seconds:60.4, div: 1.0, rem: 0.4, master:01:00, this-pr:01:00
```