### PR TITLE
Adjust the Terminal stubs to support MacOS

### DIFF
--- a/src/terminal/terminal_stubs.c
+++ b/src/terminal/terminal_stubs.c
@@ -11,7 +11,7 @@
 // Detect platform
 #if defined(_WIN32) || defined (_WIN64)
 #define OCAML_TERMINAL_WINDOWS
-#elif defined(__unix__) || defined(__unix)
+#elif defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #if defined(_POSIX_VERSION)
 #define OCAML_TERMINAL_POSIX


### PR DESCRIPTION
The existing POSIX stubs should be fine. (Tested to work on 11.2.3.)

Fixes #12. CC @Ngoguey42: when you get time, can you check these work on your machine?