### PR TITLE
Add ability to dynamically remove lines from display

### DIFF
--- a/examples/download.ml
+++ b/examples/download.ml
@@ -34,6 +34,13 @@ end
 type t = { mutable active_workers : Worker.t list; mutable files : int list }
 
 let run () =
+  let remove_lines =
+    (* Run with [REMOVE_LINES=true] to see bars being removed from the
+       display after the download is done. *)
+    match Sys.getenv_opt "REMOVE_LINES" with
+    | None | Some "false" -> false
+    | Some _ -> true
+  in
   let total_files = 18 in
   let files = List.init total_files (fun _ -> Random.int 100_000_000) in
 
@@ -51,7 +58,9 @@ let run () =
   let nb_workers = 5 in
   let finish_item (worker : Worker.t) =
     Reporter.finalise (Option.get worker.reporter);
-    completed ()
+    completed ();
+    if remove_lines then
+      Display.remove_line display (Option.get worker.reporter)
   in
   let pick_item t (worker : Worker.t) =
     match t.files with

--- a/src/progress/engine/import.ml
+++ b/src/progress/engine/import.ml
@@ -28,6 +28,12 @@ module Vector = struct
     done;
     Vector.set t k v
 
+  let remove t k =
+    for i = k to Vector.length t - 2 do
+      Vector.set t i (Vector.get t (succ i))
+    done;
+    ignore (Vector.pop t)
+
   let get_exn = get
   let get = `shadowed
 end

--- a/src/progress/engine/import.ml
+++ b/src/progress/engine/import.ml
@@ -21,6 +21,16 @@ module Vector = struct
       f i (unsafe_get t i)
     done
 
+  let rec find_map_from i t ~f =
+    if i >= length t - 1 then None
+    else
+      let a = unsafe_get t i in
+      match f a with
+      | Some _ as some -> some
+      | None -> find_map_from (i + 1) t ~f
+
+  let find_map t ~f = find_map_from 0 t ~f
+
   let insert t k v =
     Vector.push t v (* Dummy insertion to expand *);
     for i = Vector.length t - 1 downto k + 1 do

--- a/src/progress/engine/import.ml
+++ b/src/progress/engine/import.ml
@@ -22,7 +22,7 @@ module Vector = struct
     done
 
   let rec find_map_from i t ~f =
-    if i >= length t - 1 then None
+    if i >= length t then None
     else
       let a = unsafe_get t i in
       match f a with

--- a/src/progress/engine/import.ml
+++ b/src/progress/engine/import.ml
@@ -38,11 +38,11 @@ module Vector = struct
     done;
     Vector.set t k v
 
-  let remove t k =
+  let remove (type a) (t : a t) k =
     for i = k to Vector.length t - 2 do
       Vector.set t i (Vector.get t (succ i))
     done;
-    ignore (Vector.pop t)
+    ignore (Vector.pop t : a)
 
   let get_exn = get
   let get = `shadowed

--- a/src/progress/engine/renderer.ml
+++ b/src/progress/engine/renderer.ml
@@ -265,9 +265,9 @@ end = struct
           match
             Vector.find_map t.rows ~f:(function
               | None -> None
-              | Some (E bar as some_bar) ->
+              | Some (E bar) as some_bar ->
                   if Bar_id.equal key (Bar_renderer.id bar.renderer) then
-                    Some some_bar
+                    some_bar
                   else None)
           with
           | Some bar -> bar

--- a/src/progress/engine/renderer.ml
+++ b/src/progress/engine/renderer.ml
@@ -264,9 +264,8 @@ end = struct
       ~unconditional:true t
 
   let remove_line t key =
-    let exception Line_not_found in
     match Hashtbl.find t.positions key with
-    | exception Not_found -> raise Line_not_found
+    | exception Not_found -> failwith "No such line in display"
     | None -> () (* Already removed *)
     | Some { contents = position } ->
         if Hashtbl.mem t.bars key then Hashtbl.remove t.bars key;
@@ -542,7 +541,8 @@ module Make (Platform : Platform.S) = struct
     let remove_line t (reporter : _ Reporter.t) =
       match Global.find_display t.uid with
       | Error `finalised ->
-          failwith "Cannot remove a line to a finalised display"
+          failwith
+            "Cannot remove a line from a display that is already finalised"
       | Ok d -> Display.remove_line d reporter.uid
 
     let finalise t =

--- a/src/progress/engine/renderer_intf.ml
+++ b/src/progress/engine/renderer_intf.ml
@@ -154,6 +154,11 @@ module type S = sig
         ([above = 0]); the [~above] argument can be passed to add the line above
         some number of existing lines. *)
 
+    val remove_line : (_, _) t -> _ Reporter.t -> unit
+    (** Remove a line to an ongoing display, from its reporting function.
+        Removing an existing line is idempotent, but removing a line that was
+        not at point point part of the display will raise an error. *)
+
     val finalise : (_, _) t -> unit
     (** Terminate the given progress bar display. Raises [Failure] if the
         display has already been finalised. *)

--- a/src/progress/engine/renderer_intf.ml
+++ b/src/progress/engine/renderer_intf.ml
@@ -156,10 +156,9 @@ module type S = sig
 
     val remove_line : (_, _) t -> _ Reporter.t -> unit
     (** Remove a line from an ongoing display, identified by the reporting
-        function that was returned by [add_line]. Removing an existing line is
-        idempotent, but removing a line that was not at some point part of the
-        display will raise [Failure]. Also raises [Failure] if the display has
-        already been finalised. *)
+        function that was returned by [add_line]. Attempting to remove a line
+        that has already been removed from the display will raise [Failure].
+        Also raises [Failure] if the display has already been finalised. *)
 
     val finalise : (_, _) t -> unit
     (** Terminate the given progress bar display. Raises [Failure] if the

--- a/src/progress/engine/renderer_intf.ml
+++ b/src/progress/engine/renderer_intf.ml
@@ -156,9 +156,13 @@ module type S = sig
 
     val remove_line : (_, _) t -> _ Reporter.t -> unit
     (** Remove a line from an ongoing display, identified by the reporting
-        function that was returned by [add_line]. Attempting to remove a line
-        that has already been removed from the display will raise [Failure].
-        Also raises [Failure] if the display has already been finalised. *)
+        function that was returned by [add_line]. Lines may be removed either
+        before they are finalised (for example if some task has been cancelled)
+        or after being finalised. In both cases, the line will be removed from
+        the display, thus retrieving some space in the terminal. Attempting to
+        remove a line that has already been removed from the display will raise
+        [Failure]. Also raises [Failure] if the display has already been
+        finalised. *)
 
     val finalise : (_, _) t -> unit
     (** Terminate the given progress bar display. Raises [Failure] if the

--- a/src/progress/engine/renderer_intf.ml
+++ b/src/progress/engine/renderer_intf.ml
@@ -155,9 +155,11 @@ module type S = sig
         some number of existing lines. *)
 
     val remove_line : (_, _) t -> _ Reporter.t -> unit
-    (** Remove a line to an ongoing display, from its reporting function.
-        Removing an existing line is idempotent, but removing a line that was
-        not at point point part of the display will raise an error. *)
+    (** Remove a line from an ongoing display, identified by the reporting
+        function that was returned by [add_line]. Removing an existing line is
+        idempotent, but removing a line that was not at some point part of the
+        display will raise [Failure]. Also raises [Failure] if the display has
+        already been finalised. *)
 
     val finalise : (_, _) t -> unit
     (** Terminate the given progress bar display. Raises [Failure] if the


### PR DESCRIPTION
This PR proposes to add the ability to dynamically remove a line from a display.

The use cases I have in mind are :
- some work gets dynamically canceled;
- during the traversal of a large data structure yielding many progress lines, one may want to clean up old finalized lines, e.g. as new one comes along.

Please feel free to comment / argue.

Implementation notes:

- Added function `Display.remove_line` to remove a line from the display.
- I used the type Reporter as identifier for the line to remove, as this is the type returned by `add_line`, so the API has some symmetry to it.
- In order to be able to remove finalized lines, the position of the line has to be retained, thus I added a new table. This may get further polished (keen on getting feedback on this by the author).
- Added env var to download example to test and exercise the new function.
```sh
$ REMOVE_LINES=true dune exec ./examples/main.exe -- download
````