### PR TITLE
change: use float in flow_meter per-second

### DIFF
--- a/src/progress/engine/flow_meter.ml
+++ b/src/progress/engine/flow_meter.ml
@@ -58,10 +58,10 @@ let fold =
   in
   fun t ~f ~init -> aux t.data f init (t.length - 1)
 
-let per_second : type a. a t -> a =
+let per_second : type a. a t -> float =
  fun t ->
   let (module Integer) = t.elt in
-  if is_empty t then Integer.zero
+  if is_empty t then 0.
   else
     (* Sum all values in the window {i except the first one} and divide by the
        time interval. We can think of the first value as representing work done
@@ -78,10 +78,8 @@ let per_second : type a. a t -> a =
       let end_time = t.timestamps.(t.most_recently_added) in
       Mtime.span_to_s (Mtime.span start_time end_time)
     in
-    if Float.compare interval Float.epsilon < 0 then Integer.zero
-    else
-      let est = Integer.to_float sum /. interval in
-      Integer.of_float est
+    if Float.compare interval Float.epsilon < 0 then 0.
+    else Integer.to_float sum /. interval
 
 (*————————————————————————————————————————————————————————————————————————————
    Copyright (c) 2020–2021 Craig Ferguson <me@craigfe.io>

--- a/src/progress/engine/flow_meter.ml
+++ b/src/progress/engine/flow_meter.ml
@@ -61,7 +61,7 @@ let fold =
 let per_second : type a. a t -> float =
  fun t ->
   let (module Integer) = t.elt in
-  if is_empty t then 0.
+  if is_empty t then Float.zero
   else
     (* Sum all values in the window {i except the first one} and divide by the
        time interval. We can think of the first value as representing work done
@@ -78,7 +78,7 @@ let per_second : type a. a t -> float =
       let end_time = t.timestamps.(t.most_recently_added) in
       Mtime.span_to_s (Mtime.span start_time end_time)
     in
-    if Float.compare interval Float.epsilon < 0 then 0.
+    if Float.compare interval Float.epsilon < 0 then Float.zero
     else Integer.to_float sum /. interval
 
 (*————————————————————————————————————————————————————————————————————————————

--- a/src/progress/engine/flow_meter.mli
+++ b/src/progress/engine/flow_meter.mli
@@ -21,7 +21,7 @@ val create :
 val record : 'a t -> 'a -> unit
 (** Add a value to the ring buffer. *)
 
-val per_second : 'a t -> 'a
+val per_second : 'a t -> float
 (** Estimate the rate of change of recorded values per second. *)
 
 (*————————————————————————————————————————————————————————————————————————————

--- a/src/progress/engine/line.ml
+++ b/src/progress/engine/line.ml
@@ -586,8 +586,7 @@ module Make (Platform : Platform.S) = struct
         in
         let width = Printer.print_width pp_val + 2 in
         acc
-        @@ Primitives.contramap
-             ~f:(Acc.flow_meter >> Flow_meter.per_second >> Integer.to_float)
+        @@ Primitives.contramap ~f:(Acc.flow_meter >> Flow_meter.per_second)
         @@ Primitives.alpha ~width ~initial:(`Val 0.) pp_rate
 
       let bytes_per_sec = rate Units.Bytes.of_float
@@ -613,14 +612,13 @@ module Make (Platform : Platform.S) = struct
         @@ Primitives.contramap ~f:(fun acc ->
                let per_second = Flow_meter.per_second (Acc.flow_meter acc) in
                let acc = Acc.accumulator acc in
-               if Integer.(equal zero) per_second then Mtime.Span.max_span
+               if Float.equal 0. per_second then Mtime.Span.max_span
                else
                  let todo = Integer.(to_float (sub total acc)) in
                  if Float.(todo <= 0.) then Mtime.Span.zero
                  else
                    Mtime.Span.of_uint64_ns
-                     (Int64.of_float
-                        (todo /. Integer.to_float per_second *. 1_000_000_000.)))
+                     (Int64.of_float (todo /. per_second *. 1_000_000_000.)))
         @@ span_segment
 
       let elapsed ?(pp = Units.Duration.mm_ss) () =

--- a/src/progress/engine/line.ml
+++ b/src/progress/engine/line.ml
@@ -612,7 +612,7 @@ module Make (Platform : Platform.S) = struct
         @@ Primitives.contramap ~f:(fun acc ->
                let per_second = Flow_meter.per_second (Acc.flow_meter acc) in
                let acc = Acc.accumulator acc in
-               if Float.equal 0. per_second then Mtime.Span.max_span
+               if Float.(equal zero) per_second then Mtime.Span.max_span
                else
                  let todo = Integer.(to_float (sub total acc)) in
                  if Float.(todo <= 0.) then Mtime.Span.zero

--- a/src/progress/tests/test_flow_meter.ml
+++ b/src/progress/tests/test_flow_meter.ml
@@ -14,7 +14,7 @@ let gen_test_state () =
   let check pos v =
     Alcotest.(check ~pos int)
       "Expected flow rate" v
-      (Flow_meter.per_second flow_meter)
+      (Flow_meter.per_second flow_meter |> Int.of_float)
   in
   (record, check)
 


### PR DESCRIPTION
Allow `Line.eta` to display a duration for slow processes.

This experiments with @pveber proposal from https://github.com/CraigFe/progress/issues/23, namely changing `Flow_meter.per_second` to return a `float`.

Note, the eta does not refresh as time passes, unlike `Line.elapse`, so possibly more changes are needed to improve further the display for slow processes (not done here).

I tested it with a slow process on my machine, and witnessed the display go from `--:--` to an actual value after 2 reported updates.

