### PR TITLE
Use actual printer width for elapsed segment instead of fixed width=5

### DIFF
--- a/src/progress/engine/line.ml
+++ b/src/progress/engine/line.ml
@@ -625,6 +625,7 @@ module Make (Platform : Platform.S) = struct
 
       let elapsed ?(pp = Units.Duration.mm_ss) () =
         let print_time = Staged.prj (Printer.Internals.to_line_printer pp) in
+        let width = Printer.print_width pp in
         let segment =
           Primitives.stateful (fun () ->
               let elapsed = Clock.counter () in
@@ -639,7 +640,7 @@ module Make (Platform : Platform.S) = struct
                 | `rerender | `finish -> ());
                 print_time buf !latest
               in
-              Primitives.theta ~width:5 pp)
+              Primitives.theta ~width pp)
         in
         Basic segment
 


### PR DESCRIPTION
Current implementation forces fixed width=5 for elapsed segments, which is not sufficient when using other formats than `mm:ss` such as `elapsed ~pp:Progress.Units.Duration.hh_mm_ss () `.
This made the calculated length for the bar incorrect, and results in unwanted line wraps.
Using the width declared in the printer seems to fix the problem.