### PR TITLE
Update to `mtime.2.0.0`

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.17.0
+version = 0.25.1
 profile = conventional
 
 parse-docstrings

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@ progress bar formats. Supports rendering multiple progress bars simultaneously.\
   (terminal (= :version))
   (fmt (>= 0.8.5))
   (logs (>= 0.7.0))
-  (mtime (>= 1.1.0))
+  (mtime (>= 2.0.0))
   (uucp (>= 2.0.0))
   (uutf (>= 1.0.0))
   vector
@@ -42,4 +42,4 @@ progress bar formats. Supports rendering multiple progress bars simultaneously.\
   (alcotest (and :with-test (>= 1.4.0)))
   (fmt :with-test)
   (astring :with-test)
-  (mtime (and :with-test (>= 1.1.0)))))
+  (mtime (and :with-test (>= 2.0.0)))))

--- a/progress.opam
+++ b/progress.opam
@@ -16,7 +16,7 @@ depends: [
   "terminal" {= version}
   "fmt" {>= "0.8.5"}
   "logs" {>= "0.7.0"}
-  "mtime" {>= "1.1.0"}
+  "mtime" {>= "2.0.0"}
   "uucp" {>= "2.0.0"}
   "uutf" {>= "1.0.0"}
   "vector"

--- a/src/progress/engine/flow_meter.ml
+++ b/src/progress/engine/flow_meter.ml
@@ -2,6 +2,7 @@
    Copyright (c) 2020–2021 Craig Ferguson <me@craigfe.io>
    Distributed under the MIT license. See terms at the end of this file.
   ————————————————————————————————————————————————————————————————————————————*)
+open! Import
 
 type 'a t =
   { data : 'a array
@@ -75,7 +76,7 @@ let per_second : type a. a t -> a =
     let interval =
       let start_time = t.timestamps.(oldest_index) in
       let end_time = t.timestamps.(t.most_recently_added) in
-      Mtime.Span.to_s (Mtime.span start_time end_time)
+      Mtime.span_to_s (Mtime.span start_time end_time)
     in
     if Float.compare interval Float.epsilon < 0 then Integer.zero
     else

--- a/src/progress/engine/import.ml
+++ b/src/progress/engine/import.ml
@@ -5,6 +5,12 @@
 
 include Stdlib_ext
 
+module Mtime = struct
+  include Mtime
+
+  let span_to_s span = Mtime.Span.to_float_ns span *. 1e-9
+end
+
 module Vector = struct
   include Vector
 

--- a/src/progress/engine/line.ml
+++ b/src/progress/engine/line.ml
@@ -213,18 +213,7 @@ module Integer_independent (Platform : Platform.S) = struct
 
     let default =
       v ~final_frame:(Some "✔️") ~width:1
-        ~frames:
-          [| "⠋"
-           ; "⠙"
-           ; "⠹"
-           ; "⠸"
-           ; "⠼"
-           ; "⠴"
-           ; "⠦"
-           ; "⠧"
-           ; "⠇"
-           ; "⠏"
-          |]
+        ~frames:[| "⠋"; "⠙"; "⠹"; "⠸"; "⠼"; "⠴"; "⠦"; "⠧"; "⠇"; "⠏" |]
 
     let stage_count t = Array.length t.frames
   end
@@ -297,8 +286,7 @@ module Bar_style = struct
     { delimiters = Some ("│", "│")
     ; blank_space = " "
     ; full_space = "█"
-    ; in_progress_stages =
-        [| " "; "▏"; "▎"; "▍"; "▌"; "▋"; "▊"; "▉" |]
+    ; in_progress_stages = [| " "; "▏"; "▎"; "▍"; "▌"; "▋"; "▊"; "▉" |]
     ; color = None
     ; color_empty = None
     ; total_delimiter_width = 2
@@ -611,8 +599,10 @@ module Make (Platform : Platform.S) = struct
             fun ppf event x ->
               match event with
               | `finish -> pp ppf Mtime.Span.max_span (* renders as [--:--] *)
-              | `report | `rerender | `tick
-              (* TODO: tick should cause the estimate to be re-evaluated. *) ->
+              | `report | `rerender
+              | `tick
+                (* TODO: tick should cause the estimate to be re-evaluated. *)
+                ->
                   pp ppf x
           in
           let width = Printer.print_width Units.Duration.mm_ss in

--- a/src/progress/engine/renderer.ml
+++ b/src/progress/engine/renderer.ml
@@ -11,8 +11,8 @@ open! Import
 module Bar_id = Unique_id ()
 
 (* TODO: this module should probably be inlined with the
-  [Line_primitives.Compiled.t] types: since those values only ever correspond to
-  exactly one [Bar_renderer], and both are responsible for state management. *)
+   [Line_primitives.Compiled.t] types: since those values only ever correspond to
+   exactly one [Bar_renderer], and both are responsible for state management. *)
 module Bar_renderer : sig
   type 'a t
 

--- a/src/progress/engine/units.ml
+++ b/src/progress/engine/units.ml
@@ -69,7 +69,7 @@ end
 module Duration = struct
   let mm_ss =
     let to_string span =
-      let seconds = Mtime.Span.to_s span in
+      let seconds = Mtime.span_to_s span in
       if Float.compare seconds 0. < 0 then "--:--"
       else
         Printf.sprintf "%02.0f:%02.0f"
@@ -80,7 +80,7 @@ module Duration = struct
 
   let hh_mm_ss =
     let to_string span =
-      let seconds = Mtime.Span.to_s span in
+      let seconds = Mtime.span_to_s span in
       if Float.compare seconds 0. < 0 then "--:--:--"
       else
         Printf.sprintf "%02.0f:%02.0f:%02.0f"

--- a/src/terminal/terminal.mli
+++ b/src/terminal/terminal.mli
@@ -14,9 +14,9 @@ module Color : sig
 
       Colours built using {!ansi} will be rendered using the standard
       {{:https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit} 4-bit
-      ANSI escape codes} for terminals. The actual colours displayed to the user
-      depend on their terminal configuration / theme, ensuring that they look
-      natural in context. *)
+        ANSI escape codes} for terminals. The actual colours displayed to the
+      user depend on their terminal configuration / theme, ensuring that they
+      look natural in context. *)
 
   type plain =
     [ `black | `blue | `cyan | `green | `magenta | `red | `white | `yellow ]

--- a/terminal.opam
+++ b/terminal.opam
@@ -17,7 +17,7 @@ depends: [
   "alcotest" {with-test & >= "1.4.0"}
   "fmt" {with-test}
   "astring" {with-test}
-  "mtime" {with-test & >= "1.1.0"}
+  "mtime" {with-test & >= "2.0.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
In `mtime.2.0.0` quite a few utility functions were removed leaving it to the user to add them back in, these are the corresponding `mtime.1.4.0` implementations.

~p.s. I've hopefully used functions that Mtime used to use for these functions so I'm hoping this change won't need a `mtime >= 2.0.0` constraint.~

The implementation wasn't quite what Mtime does (it has a few bounds check when converting to floats) so I've just used `mtime.2.0.0` and added the lower bound.