### PR TITLE
Upgrade to ocamlformat 0.25.1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.17.0
+version = 0.25.1
 profile = conventional
 
 parse-docstrings

--- a/src/progress/engine/line.ml
+++ b/src/progress/engine/line.ml
@@ -213,18 +213,7 @@ module Integer_independent (Platform : Platform.S) = struct
 
     let default =
       v ~final_frame:(Some "✔️") ~width:1
-        ~frames:
-          [| "⠋"
-           ; "⠙"
-           ; "⠹"
-           ; "⠸"
-           ; "⠼"
-           ; "⠴"
-           ; "⠦"
-           ; "⠧"
-           ; "⠇"
-           ; "⠏"
-          |]
+        ~frames:[| "⠋"; "⠙"; "⠹"; "⠸"; "⠼"; "⠴"; "⠦"; "⠧"; "⠇"; "⠏" |]
 
     let stage_count t = Array.length t.frames
   end
@@ -297,8 +286,7 @@ module Bar_style = struct
     { delimiters = Some ("│", "│")
     ; blank_space = " "
     ; full_space = "█"
-    ; in_progress_stages =
-        [| " "; "▏"; "▎"; "▍"; "▌"; "▋"; "▊"; "▉" |]
+    ; in_progress_stages = [| " "; "▏"; "▎"; "▍"; "▌"; "▋"; "▊"; "▉" |]
     ; color = None
     ; color_empty = None
     ; total_delimiter_width = 2
@@ -611,8 +599,10 @@ module Make (Platform : Platform.S) = struct
             fun ppf event x ->
               match event with
               | `finish -> pp ppf Mtime.Span.max_span (* renders as [--:--] *)
-              | `report | `rerender | `tick
-              (* TODO: tick should cause the estimate to be re-evaluated. *) ->
+              | `report | `rerender
+              | `tick
+                (* TODO: tick should cause the estimate to be re-evaluated. *)
+                ->
                   pp ppf x
           in
           let width = Printer.print_width Units.Duration.mm_ss in

--- a/src/progress/engine/renderer.ml
+++ b/src/progress/engine/renderer.ml
@@ -11,8 +11,8 @@ open! Import
 module Bar_id = Unique_id ()
 
 (* TODO: this module should probably be inlined with the
-  [Line_primitives.Compiled.t] types: since those values only ever correspond to
-  exactly one [Bar_renderer], and both are responsible for state management. *)
+   [Line_primitives.Compiled.t] types: since those values only ever correspond to
+   exactly one [Bar_renderer], and both are responsible for state management. *)
 module Bar_renderer : sig
   type 'a t
 

--- a/src/terminal/terminal.mli
+++ b/src/terminal/terminal.mli
@@ -14,9 +14,9 @@ module Color : sig
 
       Colours built using {!ansi} will be rendered using the standard
       {{:https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit} 4-bit
-      ANSI escape codes} for terminals. The actual colours displayed to the user
-      depend on their terminal configuration / theme, ensuring that they look
-      natural in context. *)
+        ANSI escape codes} for terminals. The actual colours displayed to the
+      user depend on their terminal configuration / theme, ensuring that they
+      look natural in context. *)
 
   type plain =
     [ `black | `blue | `cyan | `green | `magenta | `red | `white | `yellow ]


### PR DESCRIPTION
A simple upgrade of `ocamlformat` to resynchronize all pending PRs.