### PR TITLE
Add pause/resume functions

### DIFF
--- a/src/progress/engine/renderer.ml
+++ b/src/progress/engine/renderer.ml
@@ -116,6 +116,8 @@ module Display : sig
   val initial_render : t -> unit
   val tick : t -> unit
   val handle_width_change : t -> int -> unit
+  val pause : t -> unit
+  val resume : t -> unit
   val interject_with : t -> (unit -> 'a) -> 'a
   val cleanup : t -> unit
   val finalise : t -> unit
@@ -317,15 +319,19 @@ end = struct
     Terminal.Ansi.move_up ppf (Vector.length rows - 1);
     rerender_all_from_top ~stage:`tick ~starting_at:0 ~unconditional:false t
 
-  let interject_with ({ config = { ppf; _ }; rows; _ } as t) f =
+  let pause { config = { ppf; _ }; rows; _ } =
     Format.fprintf ppf "%s%!" Terminal.Ansi.erase_line;
     for _ = 1 to Vector.length rows - 1 do
       Format.fprintf ppf "%a%s%!" Terminal.Ansi.move_up 1
         Terminal.Ansi.erase_line
-    done;
-    Fun.protect f ~finally:(fun () ->
-        rerender_all_from_top ~stage:`update ~starting_at:0 ~unconditional:true
-          t)
+    done
+
+  let resume t =
+    rerender_all_from_top ~stage:`update ~starting_at:0 ~unconditional:true t
+
+  let interject_with t f =
+    pause t;
+    Fun.protect f ~finally:(fun () -> resume t)
 
   let cleanup { config; _ } =
     if config.hide_cursor then
@@ -564,6 +570,16 @@ module Make (Platform : Platform.S) = struct
       | Ok d -> Display.tick d
 
     let reporters t = t.initial_reporters
+
+    let pause t =
+      match Global.find_display t.uid with
+      | Error `finalised -> failwith "Cannot pause a finalised display"
+      | Ok d -> Display.pause d
+
+    let resume t =
+      match Global.find_display t.uid with
+      | Error `finalised -> failwith "Cannot pause a finalised display"
+      | Ok d -> Display.resume d
   end
 
   let with_reporters ?config t f =

--- a/src/progress/engine/renderer_intf.ml
+++ b/src/progress/engine/renderer_intf.ml
@@ -165,7 +165,12 @@ module type S = sig
         finalised. *)
 
     val pause : (_, _) t -> unit
+    (** Suspends the rendering of any active progress bar display. It can be
+        useful to compose with the [Logs] library and avoid interference when
+        printing to [stdout] / [stderr] from the rendering of progress bars. *)
+
     val resume : (_, _) t -> unit
+    (** Resume the rendering of progress bar display. *)
 
     val finalise : (_, _) t -> unit
     (** Terminate the given progress bar display. Raises [Failure] if the

--- a/src/progress/engine/renderer_intf.ml
+++ b/src/progress/engine/renderer_intf.ml
@@ -164,6 +164,9 @@ module type S = sig
         [Failure]. Also raises [Failure] if the display has already been
         finalised. *)
 
+    val pause : (_, _) t -> unit
+    val resume : (_, _) t -> unit
+
     val finalise : (_, _) t -> unit
     (** Terminate the given progress bar display. Raises [Failure] if the
         display has already been finalised. *)


### PR DESCRIPTION
This PR adds pause/resume functions, which are a bit more expressive version of the `interject_with` function.

Without these functions (i.e. only using the `interject_with` function), it does not seem possible to implement a `fprintf`-like logging function, i.e. a function `log : Format.formatter -> ('a, Format.formatter, unit) format -> 'a` that properly stops rendering of progress bars, does the logging, and then resume printing of the progress bars. The problem part is that such a `fprintf`-like function returns a function that consumes the printing argument.

This is based on #30